### PR TITLE
Links between pegmatite and mineral mentions

### DIFF
--- a/output/target_minerals.csv
+++ b/output/target_minerals.csv
@@ -1,0 +1,8 @@
+docid,sentid,target_id,target_word,target_mineral_id,target_mineral_link,target_mineral
+55adf5cde13823763a830891,507,7,pegmatites,4003,http://www.mindat.org/min-4003.html,tourmaline
+55adf5cde13823763a830891,2143,8,pegmatite,1389,http://www.mindat.org/min-1389.html,epidote
+55adf5cde13823763a830891,2143,8,pegmatite,11468,https://www.mindat.org/min-11468.html,chlorite
+55b6cd71e13823bd29ba7d93,2573,9,pegmatite,1209,http://www.mindat.org/min-1209.html,Copper
+55b6cd71e13823bd29ba7d93,2616,10,pegmatite,2815,http://www.mindat.org/min-2815.html,muscovite
+55b6cd71e13823bd29ba7d93,2720,13,pegmatite,2815,http://www.mindat.org/min-2815.html,muscovite
+55b6cd71e13823bd29ba7d93,2720,14,pegmatite,2815,http://www.mindat.org/min-2815.html,muscovite

--- a/run.py
+++ b/run.py
@@ -30,6 +30,10 @@ os.system('python ./udf/buildbib.py')
 print('Step 3: Find stromatolite instances ...')
 os.system('python ./udf/ext_target.py')
 
+#FIND MINERAL NAMES 
+print('Step 3: Find stromatolite instances ...')
+os.system('python ./udf/ext_target_minerals.py')
+
 #FIND STRATIGRAPHIC ENTITIES
 print('Step 4: Find stratigraphic entities ...')
 os.system('python ./udf/ext_strat_phrases.py')

--- a/udf/ext_target.py
+++ b/udf/ext_target.py
@@ -76,6 +76,7 @@ for line in cursor:
         matches = [m.start() for m in re.finditer(name, sent.lower())]
 
         if matches:
+
             # if at least one match is found, count number of spaces backward
             # to arrive at word index
             indices = [sent[0:m].count(' ') for m in matches]

--- a/udf/ext_target_minerals.py
+++ b/udf/ext_target_minerals.py
@@ -1,0 +1,112 @@
+# ==============================================================================
+# TARGET ADJECTIVE EXTRACTOR
+# ==============================================================================
+
+# import relevant modules and data
+# ==============================================================================
+import time
+import random
+import re
+import yaml
+import psycopg2
+from psycopg2.extensions import AsIs
+from yaml import Loader
+
+from download_csv import download_csv
+
+start_time = time.time()
+
+# Connect to Postgres
+with open('./credentials', 'r') as credential_yaml:
+    credentials = yaml.load(credential_yaml, Loader=Loader)
+
+with open('./config', 'r') as config_yaml:
+    config = yaml.load(config_yaml, Loader=Loader)
+
+# Connect to Postgres
+connection = psycopg2.connect(
+    password=credentials['postgres']['password'],
+    dbname=credentials['postgres']['database'],
+    user=credentials['postgres']['user'],
+    host=credentials['postgres']['host'],
+    port=credentials['postgres']['port'])
+cursor = connection.cursor()
+
+# IMPORT TARGETS WITH DEPENDENTS
+cursor.execute("""
+    SELECT docid, sentid, target_id, target_word, target_children
+    FROM target_instances
+    WHERE target_children<>'[[]]';
+""")
+
+target = cursor.fetchall()
+
+# IMPORT THE SENTENCES DUMP
+cursor.execute("""
+    WITH temp as (
+            SELECT DISTINCT ON (docid, sentid) docid, sentid
+		     FROM target_instances
+            WHERE target_children<>'[[]]'
+    )
+
+
+    SELECT s.docid, s.sentid, words, poses
+    FROM %(my_app)s_sentences_%(my_product)s AS s
+
+	JOIN temp ON temp.docid=s.docid AND temp.sentid=s.sentid;
+    """, {
+    "my_app": AsIs(config['app_name']),
+    "my_product": AsIs(config['product'].lower())
+})
+
+sentences = cursor.fetchall()
+
+# initalize the target_instances table
+cursor.execute("""
+    DELETE FROM target_minerals;
+""")
+
+# push drop/create to the database
+connection.commit()
+
+# Grab the mineral metadata from Macrostrat
+minerals = download_csv('https://macrostrat.org/api/v2/defs/minerals?all&format=csv')
+mineral_names = [name.lower() for name in minerals['mineral']]
+
+adj = []
+for idx, line in enumerate(target):
+    docid, sentid, target_id, target_word, target_children = line
+    target_children = eval(target_children)
+    target_children = target_children[0]
+
+
+    sent = [elem for elem in sentences if elem[0]
+            == docid and elem[1] == sentid]
+
+    for c in target_children:
+        pos = sent[0][3][c]
+        token = sent[0][2][c]
+        print(pos, token)
+        if pos == 'NN' and token.lower() in mineral_names:
+
+            # TODO add mineral link and ID
+            # write to PSQL table
+            cursor.execute("""
+                INSERT INTO target_minerals(   docid,
+                                                sentid,
+                                                target_id,
+                                                target_word,
+                                                target_mineral)
+
+                VALUES (%s, %s, %s, %s, %s);""",
+                           (docid, sentid, target_id,
+                            target_word, token)
+                           )
+        if c < 0:
+            print('something is up!')
+
+# push insertions to the database
+connection.commit()
+
+# close the connection
+connection.close()

--- a/udf/ext_target_minerals.py
+++ b/udf/ext_target_minerals.py
@@ -1,9 +1,4 @@
-# ==============================================================================
-# TARGET ADJECTIVE EXTRACTOR
-# ==============================================================================
-
-# import relevant modules and data
-# ==============================================================================
+""" Extract mentions of minerals and link to mindat"""
 import time
 import random
 import re

--- a/udf/initdb.py
+++ b/udf/initdb.py
@@ -48,7 +48,7 @@ cursor.execute("""
 """)
 connection.commit()
 
-#TARGET_ADJECTIVES    
+#TARGET_ADJECTIVES
 cursor.execute("""
     DROP TABLE IF EXISTS target_adjectives CASCADE;
     CREATE TABLE target_adjectives(
@@ -59,6 +59,21 @@ cursor.execute("""
         target_adjective text);
 """)
 connection.commit()
+
+#TARGET_MINERALS
+cursor.execute("""
+    DROP TABLE IF EXISTS target_minerals CASCADE;
+    CREATE TABLE target_minerals (
+        docid text,
+        sentid int,
+        target_id int,
+        target_word text,
+        target_mineral_id int,
+        target_mineral_link text,
+        target_mineral text);
+""")
+connection.commit()
+
 
 #STRAT_PHRASES
 cursor.execute("""
@@ -117,6 +132,7 @@ cursor.execute("""
         );
 """)
 connection.commit()
+
 
 #AGE CHECK
 cursor.execute("""

--- a/var/target_variables.txt
+++ b/var/target_variables.txt
@@ -6,6 +6,7 @@
 #   EXAMPLE:    [r'\b' + ooid + r'\b', r'\b' + ooids + r'\b']
 #               will find all instances of 'ooid' or 'ooids' bound by a non-alphanumeric character
 target_names = ['pegmatite']
+mineral_names = ['']
 
 #an optional list of false hits
 bad_words = []


### PR DESCRIPTION
This is a first cut of extending the application to also extract all mentions of minerals correlated with key terms, it would be good to know what you think of it at this stage Joe

We check all nouns in sentences of interest against the mindat taxonomy in Macrostrat here: https://macrostrat.org/api/v2/defs/minerals 

At the moment we are 

1. only looking in the current sentence, where we could optionally explore a few
2. Not filtering on a set list of mineral names, just looking for all of them
3. not exploring the grammatical links between our keywords, and found minerals. There is code elsewhere in the original exploring the "dependency paths" between words, that we could potentially make more of (i am not sure the previous approach is right, as it stands) https://github.com/metazool/pegmatites-xDD/blob/master/udf/ext_target.py#L101
4. Not yet doing any output of this info into the final results, because those are so heavily filtered by Macrostrat-valid stratigraphic names, we're just storing them in an intermediate table, one simple approach would be to add the sentence to that table and dump it to CSV. There is a sample of the output CSV from doing this with the test dataset, in the PR

## To test

You should still be able to test this in your Windows environment with Postgres installed. For python development Anaconda with python version 3.7 is recommended. This modified version runs under python3* but should still be back compatible with 2.7.

Edit `credentials` to add the username/password details configured when setting up Postgres
```
pip install -r requirements.txt  # install the python package dependencies
$Env:PYTHONPATH="."
python setup/setup.py # create the database
python run.py # set up the database schema and run the scripts one-by-one
```

The resulting mineral list will be in the `target_minerals` table in the `pegmatites` database
